### PR TITLE
Taglib body() closure fix

### DIFF
--- a/grails-app/taglib/freemarker/tags/test/SimpleTagLib.groovy
+++ b/grails-app/taglib/freemarker/tags/test/SimpleTagLib.groovy
@@ -21,6 +21,10 @@ class SimpleTagLib {
         out << body() << (attrs.happy == 'true' ? " :-)" : " :-(")
     }
 
+	def reverse = { attrs, body ->
+		out << (body() as String).reverse()
+	}
+
     def dateFormat = { attrs, body ->
         out << new java.text.SimpleDateFormat(attrs.format).format(attrs.date)
     }

--- a/src/java/grails/plugin/freemarker/TagLibToDirectiveAndFunction.java
+++ b/src/java/grails/plugin/freemarker/TagLibToDirectiveAndFunction.java
@@ -17,6 +17,7 @@ package grails.plugin.freemarker;
 
 import java.io.CharArrayWriter;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Collections;
 import java.util.Iterator;
@@ -181,6 +182,7 @@ public class TagLibToDirectiveAndFunction implements TemplateDirectiveModel,
                             ObjectWrapper objectWrapper = env.getObjectWrapper();
                             Map<String, TemplateModel> oldVariables = null;
                             TemplateModel oldIt = null;
+                            StringWriter bodyOutput = new StringWriter();
 
                             if (log.isDebugEnabled()) {
                                 log.debug("doCall it " + it);
@@ -211,7 +213,8 @@ public class TagLibToDirectiveAndFunction implements TemplateDirectiveModel,
                                         env.setVariable("it",objectWrapper.wrap(it));
                                     }
                                 }
-                                body.render((Writer) tagInstance.getProperty("out"));
+
+                                body.render(bodyOutput);
                             } finally {
                                 if (oldVariables != null) {
                                     for (Map.Entry<String, TemplateModel> entry : oldVariables.entrySet()) {
@@ -222,7 +225,7 @@ public class TagLibToDirectiveAndFunction implements TemplateDirectiveModel,
                                 }
                             }
 
-                            return "";
+                            return bodyOutput.getBuffer().toString();
                         }
 
                     };

--- a/test/integration/grails/plugin/freemarker/UserDefinedTagLibTests.groovy
+++ b/test/integration/grails/plugin/freemarker/UserDefinedTagLibTests.groovy
@@ -27,7 +27,11 @@ class UserDefinedTagLibTests extends GroovyTestCase {
 
     def freemarkerConfig
     private StringWriter sWriter = new StringWriter()
-    
+
+	void testReverse() {
+		String result = parseFtlTemplate('[#ftl/][@g.reverse]Hi Sam[/@g.reverse]');
+		assertEquals 'maS iH', result
+	}
 
     void testEmoticon() {
         String result = parseFtlTemplate('[#ftl/][@g.emoticon happy="true"]Hi John[/@g.emoticon]');


### PR DESCRIPTION
Hi there,

To quote the commit message in this pull request:

Currently, if `body()` is executed in a Grails taglib called from a Freemarker template, TagLibToDirectiveAndFunction will simply spit the body of the taglib call out into output stream and return an empty string to the taglib. This works for *some* use cases where the body of the taglib call is just pasted into output, but for transformative stuff this doesn't work. For example if we have a taglib that reverses the body and outputs it, that kind of functionality wouldn't work without this patch.

This PR also contains a commit with a test that demonstrates what has been fixed. If you try running that test without the fa30ec4 commit, all shall become clear.