### PR TITLE
Minor tweaks

### DIFF
--- a/FreemarkerGrailsPlugin.groovy
+++ b/FreemarkerGrailsPlugin.groovy
@@ -39,7 +39,7 @@ class FreemarkerGrailsPlugin {
     //def dependsOn = [pluginConfig: '0.1.3 > *']
 
 	def observe = ["controllers", 'groovyPages']
-	def loadAfter = ['controllers', 'groovyPages']
+	def loadAfter = ['controllers', 'groovyPages', 'pluginConfig']
 	
     // resources that are excluded from plugin packaging
     def pluginExcludes = [

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,7 +1,7 @@
 grails.project.dependency.resolution = {
     def versions
     if ("$grailsVersion" > "1.3.7") {
-        versions = [geb:"0.6.2", selenium:"2.16.1", spock:"0.6-SNAPSHOT",pluginConfig:"0.1.5"]      
+        versions = [geb:"0.6.2", selenium:"2.16.1", spock:"0.6",pluginConfig:"0.1.5"]      
     }else{
         versions = [geb:"0.6.0", selenium:"2.16.1", spock:"0.5-groovy-1.7",pluginConfig:"0.1.5"]
     }


### PR DESCRIPTION
A couple of minor commits:

* `spock-0.6-SNAPSHOT` can't be found in any of the standard grails repos, so bumped it to 0.6 instead.
* Added `pluginConfig` to `dependsOn` list. We had a situation where another plugin was loading after freemarker plugin that also required pluginConfig. This was causing pluginConfig to load **after** freemarker, which was causing all kinds of crazy errors.